### PR TITLE
Add support for automatic orange break lines

### DIFF
--- a/mtheme.css
+++ b/mtheme.css
@@ -91,6 +91,27 @@ position: absolute;
   margin-bottom: -30px;
 }
 
+hr, .title-slide h2::after, .mline h1::after {
+  content: '';
+  display: block;
+  border: none;
+  background-color: #EB811B;
+  color: #EB811B;
+  height: 1px;
+}
+
+hr, .mline h1::after {
+  margin: 1em 15px 0 15px;
+}
+
+.title-slide h2::after {
+  margin: 10px 15px 35px 0;
+}
+
+.mline h1::after {
+  margin: 10px 15px 0 15px;
+}
+
 .remark-slide-number {
   font-size: 13pt;
   font-family: 'Fira Sans';

--- a/xaringan-metropolis.Rmd
+++ b/xaringan-metropolis.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "xaringan"
-subtitle: "Metropolis theme <html><div style='float:left'></div><hr color='#EB811B' size=1px width=796px></html>"
+subtitle: "Metropolis theme <html><hr color='#EB811B' size=1px, style='margin:1em 15px 0 15px'></html>"
 author: "Your Name"
 date: "2099/12/12"
 output: 
@@ -32,7 +32,7 @@ class: inverse, center, middle
 
 # Get Started
 
-<html><div style='float:left'></div><hr color='#EB811B' size=1px width=720px></html> 
+<html><hr color='#EB811B' size=1px, style='margin:1em 15px 0 15px'></html>
 
 ---
 
@@ -42,9 +42,8 @@ If you want the orange break lines in the title slide and for the slides with cl
 
 ```html
 <html>
-  <div style='float:left'></div>
-  <hr color='#EB811B' size=1px width=720px>
-</html> 
+  <hr color='#EB811B' size=1px, style='margin:1em 15px 0 15px'>
+</html>
 ```
 
 Simply put this code directly in the `title` field of the YAML header and in the body of an `inverse` slide class. 

--- a/xaringan-metropolis.Rmd
+++ b/xaringan-metropolis.Rmd
@@ -5,7 +5,10 @@ author: "Your Name"
 date: "2099/12/12"
 output: 
   xaringan::moon_reader:
-    css: [default, mtheme.css, fonts_mtheme.css]
+    css:
+      - default
+      - mtheme.css
+      - fonts_mtheme.css
     nature: 
       beforeInit: "macros.js"
       highlightStyle: github

--- a/xaringan-metropolis.Rmd
+++ b/xaringan-metropolis.Rmd
@@ -1,11 +1,11 @@
 ---
 title: "xaringan"
-subtitle: "Metropolis theme <html><hr color='#EB811B' size=1px, style='margin:1em 15px 0 15px'></html>"
+subtitle: "Metropolis theme"
 author: "Your Name"
 date: "2099/12/12"
 output: 
   xaringan::moon_reader:
-    css: [default, metropolis, metropolis-fonts]
+    css: [default, mtheme.css, fonts_mtheme.css]
     nature: 
       beforeInit: "macros.js"
       highlightStyle: github
@@ -28,25 +28,29 @@ output:
 ```
 
 ---
-class: inverse, center, middle
+class: inverse, mline, center, middle
 
 # Get Started
-
-<html><hr color='#EB811B' size=1px, style='margin:1em 15px 0 15px'></html>
 
 ---
 
 # Orange break lines
 
-If you want the orange break lines in the title slide and for the slides with class `inverse`, you need to manually insert them using
+An orange break line is automatically added for you under the subtitle in the title slide. If you want an orange break line in a slide with class `inverse`, you need to add the class `mline` too. E.g.,
 
-```html
-<html>
-  <hr color='#EB811B' size=1px, style='margin:1em 15px 0 15px'>
-</html>
+```yaml
+class: inverse, mline, center, middle
 ```
 
-Simply put this code directly in the `title` field of the YAML header and in the body of an `inverse` slide class. 
+You can also manually insert an orange break line anywhere with
+
+```html
+<hr>
+```
+
+Simply put this code directly in the `title` field of the YAML header or in the body of any slide. E.g.,
+
+<hr>
 
 ---
 


### PR DESCRIPTION
The previous recommendation only worked well for 4:3 presentations. The new recommendation works well too for 16:9 (and virtually for any other ratio).